### PR TITLE
Feat #12 브랜드별 상품 조회

### DIFF
--- a/src/main/java/com/sopt/DaisoMall/domain/product/controller/ProductController.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/controller/ProductController.java
@@ -3,9 +3,11 @@ package com.sopt.DaisoMall.domain.product.controller;
 
 import com.sopt.DaisoMall.domain.product.dto.request.ProductSearchRequest;
 import com.sopt.DaisoMall.domain.product.dto.request.ProductSortRequest;
-import com.sopt.DaisoMall.domain.product.dto.response.PopularProductListResponse;
-import com.sopt.DaisoMall.domain.product.dto.response.ProductListResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.ProductBrandResponse;
 import com.sopt.DaisoMall.domain.product.dto.response.ProductResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.list.PopularProductListResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.list.ProductBrandListResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.list.ProductListResponse;
 import com.sopt.DaisoMall.domain.product.entity.enums.SortOption;
 import com.sopt.DaisoMall.domain.product.service.PopularProductService;
 import com.sopt.DaisoMall.domain.product.service.ProductSearchService;
@@ -50,5 +52,12 @@ public class ProductController {
     public ApiResponse<PopularProductListResponse> search() {
         PopularProductListResponse response = popularProductService.getPopularProducts();
         return ApiResponse.response(HttpStatus.OK.value(), ResponseMessage.GET_POPULAR_PRODUCTS_SUCCESS.getMessage(), response);
+    }
+
+    @Operation(summary = "브랜드별 상품 조회")
+    @GetMapping("/{brandId}")
+    public ApiResponse<ProductBrandListResponse> getBrandProducts(@PathVariable Long brandId, ProductSearchRequest request) {
+        Slice<ProductBrandResponse> slice = searchService.getBrandProducts(brandId, request.pageNumber(), request.pageSize());
+        return ApiResponse.response(HttpStatus.OK.value(), ResponseMessage.GET_BRAND_PRODUCTS_SUCCESS.getMessage(), ProductBrandListResponse.of(slice));
     }
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/controller/ResponseMessage.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/controller/ResponseMessage.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public enum ResponseMessage {
     SEARCH_STORE_PRODUCTS_SUCCESS("상품 검색에 성공했습니다"),
     SORT_STORE_PRODUCTS_SUCCESS("상품 정렬에 성공했습니다"),
-    GET_POPULAR_PRODUCTS_SUCCESS("지금 많이 찾는 상품 조회에 성공했습니다");
+    GET_POPULAR_PRODUCTS_SUCCESS("지금 많이 찾는 상품 조회에 성공했습니다"),
+    GET_BRAND_PRODUCTS_SUCCESS("브랜드별 상품 조회에 성공했습니다");
 
     private final String message;
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductBrandResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductBrandResponse.java
@@ -1,0 +1,24 @@
+package com.sopt.DaisoMall.domain.product.dto.response;
+
+import com.sopt.DaisoMall.domain.product.entity.Product;
+import java.util.List;
+
+public record ProductBrandResponse(
+        Long productId,
+        String productName,
+        int price,
+        List<String> tags
+) {
+    public static ProductBrandResponse from(Product product) {
+        List<String> tagNames = product.getProductTagMappings().stream()
+                .map(mapping -> mapping.getProductTag().getDisplayName())
+                .toList();
+
+        return new ProductBrandResponse(
+                product.getId(),
+                product.getProductName(),
+                product.getPrice(),
+                tagNames
+        );
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/list/PopularProductListResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/list/PopularProductListResponse.java
@@ -1,7 +1,7 @@
-package com.sopt.DaisoMall.domain.product.dto.response;
+package com.sopt.DaisoMall.domain.product.dto.response.list;
 
+import com.sopt.DaisoMall.domain.product.dto.response.PopularProductResponse;
 import com.sopt.DaisoMall.domain.product.entity.Product;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/list/ProductBrandListResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/list/ProductBrandListResponse.java
@@ -1,0 +1,20 @@
+package com.sopt.DaisoMall.domain.product.dto.response.list;
+
+import com.sopt.DaisoMall.domain.product.dto.response.PageableResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.ProductBrandResponse;
+import java.util.List;
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+@Builder
+public record ProductBrandListResponse(
+        List<ProductBrandResponse> products,
+        PageableResponse pageable
+) {
+    public static ProductBrandListResponse of(Slice<ProductBrandResponse> slice) {
+        return ProductBrandListResponse.builder()
+                .products(slice.getContent())
+                .pageable(PageableResponse.of(slice))
+                .build();
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/list/ProductListResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/list/ProductListResponse.java
@@ -1,5 +1,7 @@
-package com.sopt.DaisoMall.domain.product.dto.response;
+package com.sopt.DaisoMall.domain.product.dto.response.list;
 
+import com.sopt.DaisoMall.domain.product.dto.response.PageableResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.ProductResponse;
 import java.util.List;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/com/sopt/DaisoMall/domain/product/entity/Product.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/entity/Product.java
@@ -2,17 +2,23 @@ package com.sopt.DaisoMall.domain.product.entity;
 
 import com.sopt.DaisoMall.domain.brand.entity.Brand;
 import com.sopt.DaisoMall.domain.product.entity.enums.Category;
+import com.sopt.DaisoMall.domain.tag.entity.ProductTagMapping;
 import com.sopt.DaisoMall.global.common.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,4 +52,7 @@ public class Product extends BaseEntity {
     @ManyToOne(optional = false)
     @JoinColumn(name = "brand_id")
     private Brand brand;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ProductTagMapping> productTagMappings = new ArrayList<>();
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/repository/ProductRepository.java
@@ -1,13 +1,24 @@
 package com.sopt.DaisoMall.domain.product.repository;
 
 import com.sopt.DaisoMall.domain.product.entity.Product;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     List<Product> findTop20ByOrderById();
+
+    @Query("""
+    SELECT DISTINCT p FROM Product p
+    LEFT JOIN FETCH p.productTagMappings ptm
+    LEFT JOIN FETCH ptm.productTag
+    WHERE p.brand.id = :brandId
+    """)
+    Slice<Product> findByBrandId(@Param("brandId") Long brandId, Pageable pageable);
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/service/PopularProductService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/service/PopularProductService.java
@@ -1,13 +1,12 @@
 package com.sopt.DaisoMall.domain.product.service;
 
-import com.sopt.DaisoMall.domain.product.dto.response.PopularProductListResponse;
+import com.sopt.DaisoMall.domain.product.dto.response.list.PopularProductListResponse;
 import com.sopt.DaisoMall.domain.product.entity.Product;
 import com.sopt.DaisoMall.domain.product.repository.ProductRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/sopt/DaisoMall/domain/product/service/ProductSearchService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/service/ProductSearchService.java
@@ -1,7 +1,9 @@
 package com.sopt.DaisoMall.domain.product.service;
 
+import com.sopt.DaisoMall.domain.product.dto.response.ProductBrandResponse;
 import com.sopt.DaisoMall.domain.product.dto.response.ProductResponse;
 import com.sopt.DaisoMall.domain.product.exception.PageNotFoundException;
+import com.sopt.DaisoMall.domain.product.repository.ProductRepository;
 import com.sopt.DaisoMall.domain.product.repository.ProductStockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProductSearchService {
+    private final ProductRepository productRepository;
     private final ProductStockRepository stockRepository;
 
     public Slice<ProductResponse> searchProducts(
@@ -29,5 +32,11 @@ public class ProductSearchService {
         return stockRepository
                 .searchByKeyword(keyword, page)
                 .map(ProductResponse::from);
+    }
+
+    public Slice<ProductBrandResponse> getBrandProducts(Long brandId, int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        return productRepository.findByBrandId(brandId, pageable)
+                .map(ProductBrandResponse::from);
     }
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/tag/entity/ProductTagMapping.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/tag/entity/ProductTagMapping.java
@@ -3,7 +3,9 @@ package com.sopt.DaisoMall.domain.tag.entity;
 import com.sopt.DaisoMall.domain.product.entity.Product;
 import com.sopt.DaisoMall.global.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -22,9 +24,11 @@ public class ProductTagMapping extends BaseEntity {
     @Id
     private Long id;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
     private Product product;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_tag_id")
     private ProductTag productTag;
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #11 

## 작업 내용 💻

- [x] 상세조회에서 조회하는 API인, 브랜드 별로 상품 모와보기 기능을 구현하겠습니다
<img width="297" alt="Image" src="https://github.com/user-attachments/assets/38209afb-8d98-4a97-afb0-efbdf2b06510" />

## 스크린샷 📷

| 첫번째 브랜드별 조회 (VT) | 
| --- | 
| ![image](https://github.com/user-attachments/assets/fa975f29-189d-4441-ad22-1e2329660d11) | 

| 두번째 브랜드별 조회 (비즈) | 
| --- | 
| ![image](https://github.com/user-attachments/assets/f440df47-6a0c-4dba-b6e3-2e9eb379846f) | 

| 없는 브랜드로 조회시 | 
| --- | 
| ![image](https://github.com/user-attachments/assets/4de6a88c-7789-4db4-ad71-169cd2298daa) | 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

1. 태그가 비어있을 시는 빈배열 반환, 없는 브랜드 조회시에도 마찬가지로 빈배열을 반환해주는 방식으로 구현했습니당
사실 브랜드 별로 모와보기에서 상품이 없을 경우는 없다고 생각하긴했지만, 검색때와 마찬가지로 통일해서 클라이언트 분들에게 보내주는게 맞겠다고 판단이 들었습니다 !

2. 해당 내용도 마찬가지로, S3 작업시에 이미지 필드까지 추가될 예정이라고 생각해주시면 될거같아여

