### PR TITLE
Feat: 상품 상세조회 기능 구현

### DIFF
--- a/src/main/java/com/sopt/DaisoMall/domain/image/controller/ResponseMessage.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/controller/ResponseMessage.java
@@ -1,0 +1,13 @@
+package com.sopt.DaisoMall.domain.image.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseMessage {
+    S3_UPLOAD_SUCCESS("S3에 이미지 업로드 성공"),
+    S3_FILE_DELETE_SUCCESS("S3에 있는 상품 이미지 삭제 성공");
+
+    private final String message;
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
@@ -1,5 +1,6 @@
 package com.sopt.DaisoMall.domain.image.controller;
 
+import com.sopt.DaisoMall.domain.image.entity.enums.ImageType;
 import com.sopt.DaisoMall.domain.image.service.ProductImageService;
 import com.sopt.DaisoMall.domain.image.service.S3Service;
 import com.sopt.DaisoMall.domain.image.dto.request.ProductImageUploadDto;
@@ -12,8 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/s3")
@@ -24,15 +23,19 @@ public class S3Controller {
 
     @Operation(summary = "(서버 테스트용) Swagger로 사진을 S3에 상품 이미지를 업로드하는 API입니다.")
     @PostMapping(value = "/upload/products", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<String> uploadProductImageToS3(@RequestPart("data") @Valid final ProductImageUploadDto productImageUploadDto, @RequestPart("file") MultipartFile file) throws IOException {
-        String imageUrl = productImageService.uploadProductImage(file, productImageUploadDto);
+    public ApiResponse<String> uploadProductImageToS3(@RequestPart("data") @Valid final ProductImageUploadDto dto, @RequestPart("file") MultipartFile file) {
+        String key = productImageService.getProductImageKey(file, dto.productId(), dto.isMain());
+        String imageUrl = s3Service.uploadToS3(file, key);
+        productImageService.saveProductImage(dto, imageUrl);
         return ApiResponse.response(HttpStatus.OK.value(), ResponseMessage.S3_UPLOAD_SUCCESS.getMessage(), imageUrl);
     }
 
-    @Operation(summary = "(서버 테스트용) productId로 S3에 업로드되어 있는 상품 이미지(메인, 디테일) 모두 삭제")
+    @Operation(summary = "(서버 테스트용) productId로 S3에 업로드되어 있는 상품 또는 리뷰 이미지 삭제")
     @DeleteMapping("/{productId}")
-    public ApiResponse<String> deleteProductImageFromS3(@PathVariable("productId") long productId){
-        s3Service.deleteProductImageFromS3(productId);
+    public ApiResponse<String> deleteImagesFromS3(@PathVariable("productId") long productId, @RequestParam("type") ImageType type){
+        String prefix = s3Service.getPrefix(type.getDisplayName(), productId);
+        s3Service.deleteFromS3(prefix);
+        productImageService.deleteProductImage(productId);
         return ApiResponse.response(HttpStatus.OK.value(), ResponseMessage.S3_FILE_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
@@ -2,14 +2,13 @@ package com.sopt.DaisoMall.domain.image.controller;
 
 import com.sopt.DaisoMall.domain.image.service.ProductImageService;
 import com.sopt.DaisoMall.domain.image.service.S3Service;
-import com.sopt.DaisoMall.domain.image.dto.ProductImageUploadDto;
+import com.sopt.DaisoMall.domain.image.dto.request.ProductImageUploadDto;
 import com.sopt.DaisoMall.global.common.dto.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
@@ -1,11 +1,39 @@
 package com.sopt.DaisoMall.domain.image.controller;
 
+import com.sopt.DaisoMall.domain.image.service.ProductImageService;
+import com.sopt.DaisoMall.domain.image.service.S3Service;
+import com.sopt.DaisoMall.domain.image.dto.ProductImageUploadDto;
+import com.sopt.DaisoMall.global.common.dto.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/s3")
 public class S3Controller {
+
+    private final S3Service s3Service;
+    private final ProductImageService productImageService;
+
+    @Operation(summary = "(서버 테스트용) Swagger로 사진을 S3에 상품 이미지를 업로드하는 API입니다.")
+    @PostMapping(value = "/upload/products", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadProductImageToS3(@RequestPart("data") @Valid final ProductImageUploadDto productImageUploadDto, @RequestPart("file") MultipartFile file) throws IOException {
+        String imageUrl = productImageService.uploadProductImage(file, productImageUploadDto);
+        return ApiResponse.response(HttpStatus.OK.value(), "이미지 업로드 성공", imageUrl);
+    }
+
+    @Operation(summary = "(서버 테스트용) productId로 S3에 업로드되어 있는 상품 이미지(메인, 디테일) 모두 삭제")
+    @DeleteMapping("/{productId}")
+    public ApiResponse<String> deleteProductImageFromS3(@PathVariable("productId") long productId){
+        s3Service.deleteProductImageFromS3(productId);
+        return ApiResponse.response(HttpStatus.OK.value(), "S3에 있는 상품 이미지 삭제 성공");
+    }
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/controller/S3Controller.java
@@ -26,13 +26,13 @@ public class S3Controller {
     @PostMapping(value = "/upload/products", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> uploadProductImageToS3(@RequestPart("data") @Valid final ProductImageUploadDto productImageUploadDto, @RequestPart("file") MultipartFile file) throws IOException {
         String imageUrl = productImageService.uploadProductImage(file, productImageUploadDto);
-        return ApiResponse.response(HttpStatus.OK.value(), "이미지 업로드 성공", imageUrl);
+        return ApiResponse.response(HttpStatus.OK.value(), ResponseMessage.S3_UPLOAD_SUCCESS.getMessage(), imageUrl);
     }
 
     @Operation(summary = "(서버 테스트용) productId로 S3에 업로드되어 있는 상품 이미지(메인, 디테일) 모두 삭제")
     @DeleteMapping("/{productId}")
     public ApiResponse<String> deleteProductImageFromS3(@PathVariable("productId") long productId){
         s3Service.deleteProductImageFromS3(productId);
-        return ApiResponse.response(HttpStatus.OK.value(), "S3에 있는 상품 이미지 삭제 성공");
+        return ApiResponse.response(HttpStatus.OK.value(), ResponseMessage.S3_FILE_DELETE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/image/dto/ProductImageUploadDto.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/dto/ProductImageUploadDto.java
@@ -1,0 +1,8 @@
+package com.sopt.DaisoMall.domain.image.dto;
+
+public record ProductImageUploadDto(
+        long productId,
+        boolean isMain, // MAIN or DETAIL
+        int sortOrder // 사진 정렬 순서
+) {
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/image/dto/request/ProductImageDto.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/dto/request/ProductImageDto.java
@@ -1,0 +1,8 @@
+package com.sopt.DaisoMall.domain.image.dto.request;
+
+public record ProductImageDto(
+        long productImageId,
+        String imageUrl,
+        int sortOrder
+) {
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/image/dto/request/ProductImageUploadDto.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/dto/request/ProductImageUploadDto.java
@@ -1,4 +1,4 @@
-package com.sopt.DaisoMall.domain.image.dto;
+package com.sopt.DaisoMall.domain.image.dto.request;
 
 public record ProductImageUploadDto(
         long productId,

--- a/src/main/java/com/sopt/DaisoMall/domain/image/entity/enums/ImageType.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/entity/enums/ImageType.java
@@ -1,0 +1,13 @@
+package com.sopt.DaisoMall.domain.image.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ImageType {
+    PRODUCT("products"),
+    REVIEW("reviews");
+
+    private final String displayName;
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/image/exception/ErrorMessage.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/exception/ErrorMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
     INVALID_FILE_NAME("파일 이름이 유효하지 않습니다"),
-    FILE_UPLOAD_FAIL("파일 업로드에 실패했습니다");
+    FILE_UPLOAD_FAIL("파일 업로드에 실패했습니다"),
+    INVALID_SORT_ORDER("정렬 순서는 0부터 시작합니다.");
 
     private final String message;
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/image/exception/InvalidSortOrderException.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/exception/InvalidSortOrderException.java
@@ -1,0 +1,10 @@
+package com.sopt.DaisoMall.domain.image.exception;
+
+import com.sopt.DaisoMall.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidSortOrderException extends BaseException {
+    public InvalidSortOrderException() {
+        super(HttpStatus.BAD_REQUEST, ErrorMessage.INVALID_SORT_ORDER.getMessage());
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/image/service/ProductImageService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/service/ProductImageService.java
@@ -1,0 +1,46 @@
+package com.sopt.DaisoMall.domain.image.service;
+
+import com.sopt.DaisoMall.domain.image.dto.ProductImageUploadDto;
+import com.sopt.DaisoMall.domain.image.exception.InvalidSortOrderException;
+import com.sopt.DaisoMall.domain.product.entity.Product;
+import com.sopt.DaisoMall.domain.product.entity.ProductImage;
+import com.sopt.DaisoMall.domain.product.exception.NotFoundProductException;
+import com.sopt.DaisoMall.domain.product.repository.ProductImageRepository;
+import com.sopt.DaisoMall.domain.product.repository.ProductRepository;
+import com.sopt.DaisoMall.global.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ProductImageService {
+
+    private final ProductRepository productRepository;
+    private final ProductImageRepository productImageRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public String uploadProductImage(MultipartFile file, ProductImageUploadDto dto) {
+        if (dto.sortOrder() < 0) throw new InvalidSortOrderException();
+
+        String category = Boolean.TRUE.equals(dto.isMain()) ? "main" : "detail";
+
+        Product product = productRepository.findById(dto.productId())
+                .orElseThrow(NotFoundProductException::new);
+
+        String imageUrl = s3Service.uploadToS3(file, dto.productId(), category);
+
+        ProductImage image = ProductImage.builder()
+                .product(product)
+                .imageUrl(imageUrl)
+                .isMain(Boolean.TRUE.equals(dto.isMain()))
+                .sortOrder(dto.sortOrder())
+                .build();
+
+        productImageRepository.save(image);
+        return imageUrl;
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/image/service/ProductImageService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/service/ProductImageService.java
@@ -1,15 +1,13 @@
 package com.sopt.DaisoMall.domain.image.service;
 
-import com.sopt.DaisoMall.domain.image.dto.ProductImageUploadDto;
+import com.sopt.DaisoMall.domain.image.dto.request.ProductImageUploadDto;
 import com.sopt.DaisoMall.domain.image.exception.InvalidSortOrderException;
 import com.sopt.DaisoMall.domain.product.entity.Product;
 import com.sopt.DaisoMall.domain.product.entity.ProductImage;
 import com.sopt.DaisoMall.domain.product.exception.NotFoundProductException;
 import com.sopt.DaisoMall.domain.product.repository.ProductImageRepository;
 import com.sopt.DaisoMall.domain.product.repository.ProductRepository;
-import com.sopt.DaisoMall.global.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/sopt/DaisoMall/domain/image/service/S3Service.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/service/S3Service.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -23,11 +22,8 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String uploadToS3(MultipartFile file, long productId, String category){
-
-        String fileName = generateFileName(file);
-        String key = String.format("products/%d/%s/%s", productId, category, fileName);
-
+    // S3 업로드
+    public String uploadToS3(MultipartFile file, String key){
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
         metadata.setContentType(file.getContentType());
@@ -41,18 +37,13 @@ public class S3Service {
         return amazonS3.getUrl(bucket, key).toString();
     }
 
-    private String generateFileName(MultipartFile file) {
-        String extension = "";
-        String original = file.getOriginalFilename();
-        if (original != null && original.contains(".")) {
-            extension = original.substring(original.lastIndexOf("."));
-        }
-        return UUID.randomUUID() + extension;
+    // productId와 관련된 디렉토리
+    public String getPrefix(String type, long productId){
+        return String.format("%s/%d/", type, productId);
     }
 
-    public void deleteProductImageFromS3(long productId){
-        String prefix = String.format("products/%d/", productId);
-
+    // S3에 있는 파일 삭제
+    public void deleteFromS3(String prefix){
         ListObjectsV2Request listRequest = new ListObjectsV2Request()
                 .withBucketName(bucket)
                 .withPrefix(prefix);

--- a/src/main/java/com/sopt/DaisoMall/domain/image/service/S3Service.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/service/S3Service.java
@@ -3,10 +3,8 @@ package com.sopt.DaisoMall.domain.image.service;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import com.sopt.DaisoMall.domain.image.exception.FileUploadFailedException;
-import com.sopt.DaisoMall.global.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/sopt/DaisoMall/domain/image/service/S3Service.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/image/service/S3Service.java
@@ -1,0 +1,80 @@
+package com.sopt.DaisoMall.domain.image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import com.sopt.DaisoMall.domain.image.exception.FileUploadFailedException;
+import com.sopt.DaisoMall.global.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadToS3(MultipartFile file, long productId, String category){
+
+        String fileName = generateFileName(file);
+        String key = String.format("products/%d/%s/%s", productId, category, fileName);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, key, inputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new FileUploadFailedException();
+        }
+        return amazonS3.getUrl(bucket, key).toString();
+    }
+
+    private String generateFileName(MultipartFile file) {
+        String extension = "";
+        String original = file.getOriginalFilename();
+        if (original != null && original.contains(".")) {
+            extension = original.substring(original.lastIndexOf("."));
+        }
+        return UUID.randomUUID() + extension;
+    }
+
+    public void deleteProductImageFromS3(long productId){
+        String prefix = String.format("products/%d/", productId);
+
+        ListObjectsV2Request listRequest = new ListObjectsV2Request()
+                .withBucketName(bucket)
+                .withPrefix(prefix);
+
+        ListObjectsV2Result result;
+        List<DeleteObjectsRequest.KeyVersion> keysToDelete = new ArrayList<>();
+
+        do {
+            result = amazonS3.listObjectsV2(listRequest);
+            for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+                keysToDelete.add(new DeleteObjectsRequest.KeyVersion(objectSummary.getKey()));
+            }
+            listRequest.setContinuationToken(result.getNextContinuationToken());
+        } while (result.isTruncated());
+
+        if (!keysToDelete.isEmpty()) {
+            DeleteObjectsRequest deleteRequest = new DeleteObjectsRequest(bucket)
+                    .withKeys(keysToDelete)
+                    .withQuiet(true);
+            amazonS3.deleteObjects(deleteRequest);
+        }
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/controller/ResponseMessage.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/controller/ResponseMessage.java
@@ -10,7 +10,8 @@ public enum ResponseMessage {
     SEARCH_STORE_PRODUCTS_SUCCESS("상품 검색에 성공했습니다"),
     SORT_STORE_PRODUCTS_SUCCESS("상품 정렬에 성공했습니다"),
     GET_POPULAR_PRODUCTS_SUCCESS("지금 많이 찾는 상품 조회에 성공했습니다"),
-    GET_BRAND_PRODUCTS_SUCCESS("브랜드별 상품 조회에 성공했습니다");
+    GET_BRAND_PRODUCTS_SUCCESS("브랜드별 상품 조회에 성공했습니다"),
+    GET_PRODUCT_DETAIL_SUCCESS("상품 상세 조회에 성공했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/querydsl/QueryResultDto.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/querydsl/QueryResultDto.java
@@ -1,15 +1,11 @@
 package com.sopt.DaisoMall.domain.product.dto.querydsl;
 
-import java.util.List;
-
 public record QueryResultDto(
         Long productId,
         String productName,
         String price,
         Double ratingAvg,
         Long reviewCount,
-        String brandName,
-        List<String> mainImages,
-        List<String> detailImages
+        String brandName
 ) {
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/querydsl/QueryResultDto.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/querydsl/QueryResultDto.java
@@ -1,0 +1,15 @@
+package com.sopt.DaisoMall.domain.product.dto.querydsl;
+
+import java.util.List;
+
+public record QueryResultDto(
+        Long productId,
+        String productName,
+        String price,
+        Double ratingAvg,
+        Long reviewCount,
+        String brandName,
+        List<String> mainImages,
+        List<String> detailImages
+) {
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductDetailResponse.java
@@ -1,5 +1,6 @@
 package com.sopt.DaisoMall.domain.product.dto.response;
 
+import com.sopt.DaisoMall.domain.image.dto.request.ProductImageDto;
 import com.sopt.DaisoMall.domain.product.dto.querydsl.QueryResultDto;
 
 import java.util.List;
@@ -11,10 +12,9 @@ public record ProductDetailResponse(
         String ratingAvg,
         String reviewCount,
         String brandName,
-        List<String> mainImages,
-        List<String> detailImages
+        ProductImageResponse productImages
 ) {
-    public static ProductDetailResponse from(QueryResultDto dto) {
+    public static ProductDetailResponse from(QueryResultDto dto, List<ProductImageDto> main, List<ProductImageDto> detail) {
         Double ratingAvg = Math.round(dto.ratingAvg() * 10.0) / 10.0;
         return new ProductDetailResponse(
                 dto.productId(),
@@ -23,8 +23,7 @@ public record ProductDetailResponse(
                 ratingAvg.toString(),
                 dto.reviewCount().toString(),
                 dto.brandName(),
-                dto.mainImages(),
-                dto.detailImages()
+                new ProductImageResponse(new ProductImageResponse.ProductImageWrapper(main, detail))
         );
     }
 

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductDetailResponse.java
@@ -1,0 +1,31 @@
+package com.sopt.DaisoMall.domain.product.dto.response;
+
+import com.sopt.DaisoMall.domain.product.dto.querydsl.QueryResultDto;
+
+import java.util.List;
+
+public record ProductDetailResponse(
+        long productId,
+        String productName,
+        String price,
+        String ratingAvg,
+        String reviewCount,
+        String brandName,
+        List<String> mainImages,
+        List<String> detailImages
+) {
+    public static ProductDetailResponse from(QueryResultDto dto) {
+        Double ratingAvg = Math.round(dto.ratingAvg() * 10.0) / 10.0;
+        return new ProductDetailResponse(
+                dto.productId(),
+                dto.productName(),
+                dto.price(),
+                ratingAvg.toString(),
+                dto.reviewCount().toString(),
+                dto.brandName(),
+                dto.mainImages(),
+                dto.detailImages()
+        );
+    }
+
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductImageResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/dto/response/ProductImageResponse.java
@@ -1,0 +1,12 @@
+package com.sopt.DaisoMall.domain.product.dto.response;
+
+import com.sopt.DaisoMall.domain.image.dto.request.ProductImageDto;
+
+import java.util.List;
+
+public record ProductImageResponse(ProductImageWrapper productImage) {
+    public record ProductImageWrapper(
+            List<ProductImageDto> main,
+            List<ProductImageDto> detail
+    ) {}
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/exception/ErrorMessage.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/exception/ErrorMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum ErrorMessage {
     NOT_FOUND_PAGE("존재하지 않는 페이지입니다"),
     NOT_FOUND_SORT_OPTION("존재하지 않는 정렬 옵션입니다"),
+    NOT_FOUND_PRODUCT("존재하지 않는 상품입니다."),
     NOT_FOUND_BRAND ("존재하지 않는 브랜드입니다");
 
     private final String message;

--- a/src/main/java/com/sopt/DaisoMall/domain/product/exception/NotFoundProductException.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/exception/NotFoundProductException.java
@@ -1,0 +1,10 @@
+package com.sopt.DaisoMall.domain.product.exception;
+
+import com.sopt.DaisoMall.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundProductException extends BaseException {
+    public NotFoundProductException() {
+        super(HttpStatus.NOT_FOUND, ErrorMessage.NOT_FOUND_PRODUCT.getMessage());
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/repository/ProductImageRepository.java
@@ -1,9 +1,12 @@
 package com.sopt.DaisoMall.domain.product.repository;
 
+import com.sopt.DaisoMall.domain.product.entity.Product;
 import com.sopt.DaisoMall.domain.product.entity.ProductImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+
+    void deleteByProduct(Product product);
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/repository/ProductImageRepository.java
@@ -1,0 +1,9 @@
+package com.sopt.DaisoMall.domain.product.repository;
+
+import com.sopt.DaisoMall.domain.product.entity.ProductImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductImageRepository extends JpaRepository<ProductImage, Long> {
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/service/ProductDetailService.java
@@ -10,6 +10,7 @@ import com.sopt.DaisoMall.domain.product.dto.response.ProductDetailResponse;
 import com.sopt.DaisoMall.domain.product.dto.response.ProductImageResponse;
 import com.sopt.DaisoMall.domain.product.entity.QProduct;
 import com.sopt.DaisoMall.domain.product.entity.QProductImage;
+import com.sopt.DaisoMall.domain.product.exception.NotFoundProductException;
 import com.sopt.DaisoMall.domain.review.entity.QReview;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,11 +27,11 @@ public class ProductDetailService {
         List<ProductImageDto> mainImages = fetchImages(productId, true);
         List<ProductImageDto> detailImages = fetchImages(productId, false);
 
-        QueryResultDto result = fetchProductDetail(productId, mainImages, detailImages);
+        QueryResultDto result = fetchProductDetail(productId);
 
-//        if (result == null) {
-//            throw new ProductNotFoundException();
-//        }
+        if (result == null) {
+            throw new NotFoundProductException();
+        }
 
         return ProductDetailResponse.from(result, mainImages, detailImages);
     }
@@ -50,7 +51,7 @@ public class ProductDetailService {
     }
 
 
-    private QueryResultDto fetchProductDetail(Long productId, List<ProductImageDto> mainImages, List<ProductImageDto> detailImages) {
+    private QueryResultDto fetchProductDetail(Long productId) {
         QProduct product = QProduct.product;
         QBrand brand = QBrand.brand;
         QReview review = QReview.review;

--- a/src/main/java/com/sopt/DaisoMall/domain/product/service/ProductDetailService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/product/service/ProductDetailService.java
@@ -1,0 +1,71 @@
+package com.sopt.DaisoMall.domain.product.service;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sopt.DaisoMall.domain.brand.entity.QBrand;
+import com.sopt.DaisoMall.domain.product.dto.querydsl.QueryResultDto;
+import com.sopt.DaisoMall.domain.product.dto.response.ProductDetailResponse;
+import com.sopt.DaisoMall.domain.product.entity.QProduct;
+import com.sopt.DaisoMall.domain.product.entity.QProductImage;
+import com.sopt.DaisoMall.domain.review.entity.QReview;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDetailService {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ProductDetailResponse getProductDetail(long productId) {
+        List<String> mainImages = fetchImages(productId, true);
+        List<String> detailImages = fetchImages(productId, false);
+
+        QueryResultDto result = fetchProductDetail(productId, mainImages, detailImages);
+
+//        if (result == null) {
+//            throw new ProductNotFoundException();
+//        }
+
+        return ProductDetailResponse.from(result);
+    }
+
+    private List<String> fetchImages(Long productId, boolean isMain) {
+        QProductImage image = QProductImage.productImage;
+        return queryFactory
+                .select(image.imageUrl)
+                .from(image)
+                .where(image.product.id.eq(productId)
+                        .and(image.isMain.eq(isMain)))
+                .orderBy(image.sortOrder.asc())
+                .fetch();
+    }
+
+    private QueryResultDto fetchProductDetail(Long productId, List<String> mainImages, List<String> detailImages) {
+        QProduct product = QProduct.product;
+        QBrand brand = QBrand.brand;
+        QReview review = QReview.review;
+
+        return queryFactory
+                .select(Projections.constructor(QueryResultDto.class,
+                        product.id,
+                        product.productName,
+                        product.price.stringValue(),
+                        review.rating.avg().coalesce(0.0),
+                        review.countDistinct(),
+                        brand.name,
+                        Expressions.constant(mainImages),
+                        Expressions.constant(detailImages)
+                ))
+                .from(product)
+                .join(product.brand, brand)
+                .leftJoin(review).on(review.product.id.eq(product.id))
+                .where(product.id.eq(productId))
+                .groupBy(product.id, brand.id)
+                .fetchOne();
+    }
+
+}

--- a/src/main/java/com/sopt/DaisoMall/domain/store/dto/response/StoreStockResponse.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/store/dto/response/StoreStockResponse.java
@@ -1,6 +1,7 @@
 package com.sopt.DaisoMall.domain.store.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
+import com.sopt.DaisoMall.domain.product.entity.enums.StockStatus;
 import com.sopt.DaisoMall.domain.store.entity.Store;
 import com.sopt.DaisoMall.domain.store.entity.StoreProductStock;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class StoreStockResponse {
     @QueryProjection
     public StoreStockResponse(long storeId, String storeName, String location, String openingHours,
                               Double latitude, Double longitude, Boolean isPickupAvailable,
-                              String floor, int shelfNo, long stockCount, String stockStatus) {
+                              String floor, int shelfNo, long stockCount, StockStatus stockStatus) {
         this.storeId = storeId;
         this.storeName = storeName;
         this.location = location;
@@ -34,7 +35,7 @@ public class StoreStockResponse {
         this.floor = floor;
         this.shelfNo = shelfNo;
         this.stockCount = stockCount;
-        this.stockStatus = stockStatus;
+        this.stockStatus = stockStatus.getDisplayName();
     }
 
     public static StoreStockResponse from(StoreProductStock stock) {
@@ -50,7 +51,7 @@ public class StoreStockResponse {
                 stock.getFloor(),
                 stock.getShelfNo(),
                 stock.getStockCount(),
-                stock.getStockStatus().getDisplayName()
+                stock.getStockStatus()
         );
     }
 }

--- a/src/main/java/com/sopt/DaisoMall/domain/store/service/StoreService.java
+++ b/src/main/java/com/sopt/DaisoMall/domain/store/service/StoreService.java
@@ -90,7 +90,7 @@ public class StoreService {
                         stock.floor,
                         stock.shelfNo,
                         stock.stockCount,
-                        stock.stockStatus.stringValue()
+                        stock.stockStatus
                 ))
                 .from(stock)
                 .join(stock.store, store)

--- a/src/main/java/com/sopt/DaisoMall/global/config/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/sopt/DaisoMall/global/config/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,30 @@
+package com.sopt.DaisoMall.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/sopt/DaisoMall/global/config/SecurityConfig.java
+++ b/src/main/java/com/sopt/DaisoMall/global/config/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                // .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## Related issue 🛠
- closed #13 

## 작업 내용 💻
- Swagger로 S3에 이미지 업로드 할 수 있도록 API 구현했습니다
- 상품 상세 조회 API를 구현했습니다.
  - 리뷰 점수는 실제 데이터를 기반으로 동적으로 계산하여 반환되도록 처리했습니다.


## 스크린샷 📷

- 상품 상세 조회 API
![image](https://github.com/user-attachments/assets/fb9ce21d-57fa-4846-8c8d-0ff8be7f4887)
![image](https://github.com/user-attachments/assets/21b5cfc3-11de-474b-b91e-8e061a22f2a8)



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- Spring Security에서는 기본적으로 CSRF 토큰 검증이 활성화되어 있는데, 제 브라우저가 해당 토큰을 가지고 있지 않아서 Security 단에서 403 Forbidden이 발생했습니다.해결 방법은 CSRF 검증을 비활성화 하는 건데, 저희 프로젝트는 로그인 세션을 사용하는 구조가 아니라서 현재로선 CSRF를 꺼도 문제는 없습니다. 다만, 로컬에서 테스트할 일이 있을 것 같아 주석 처리된 상태로 설정만 추가해두었습니다 :)

-  현재 `(productId, isMain, sortOrder)` 조합에 대한 unique 제약 조건이 없습니다. 따라서 같은 상품 내에서 동일한 `sortOrder`가 중복 저장될 수 있는 상황입니다.  추후 이 부분은 제약 조건을 추가하거나, 업로드 시 중복 정합성을 체크하는 방향으로 디벨롭할 예정입니다.



